### PR TITLE
Upgrade hashbrown to 0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ahash = { version = "0.8.0", optional = true }
 arcstr = { version = "1.1.4", optional = true }
 fxhash = { version = "0.2.1", optional = true }
 chrono = { version = "0.4.22", optional = true }
-hashbrown = { version = "0.13.2", optional = true }
+hashbrown = { version = "0.15.0", optional = true }
 bigdecimal = { version = "0.3.0", optional = true }
 xxhash-rust = { version = "0.8.6", optional = true }
 rust_decimal = { version = "1.26.1", optional = true }


### PR DESCRIPTION
https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md

Some performance improvements. Also in 0.15.0 there's this [allocation_size](https://docs.rs/hashbrown/0.15.0/hashbrown/hash_map/struct.HashMap.html#method.allocation_size) method that returns the total amount of memory allocated in bytes; I think the `SizeOf` implementation is still useful because `allocation_size` is implemented only under certain conditions:
```
impl<K, V, S, A> HashMap<K, V, S, A>
where
    K: Eq + Hash,
    S: BuildHasher,
    A: Allocator,
{
...
```